### PR TITLE
Fix silent update failures in both scripts

### DIFF
--- a/gandi-dynamic-dns.sh
+++ b/gandi-dynamic-dns.sh
@@ -7,14 +7,14 @@
 #
 
 # CHECK: curl is installed
-if [ ! command -v curl &> /dev/null ]
+if ! command -v curl &> /dev/null
 then
   echo "curl could not be found"
   exit 1
 fi
 
 # CHECK: jq is installed
-if [ ! command -v jq &> /dev/null ]
+if ! command -v jq &> /dev/null
 then
   echo "jq could not be found"
   exit 1
@@ -60,9 +60,10 @@ function valid_ip()
 }
 
 # Get current IP address
-if valid_ip $(curl -s -4 $GET_IP_WEBSITE)
+IP_NOW=$(curl -s -4 $GET_IP_WEBSITE)
+if valid_ip "$IP_NOW"
 then
-  IP_NOW=$(curl -s -4 $GET_IP_WEBSITE)
+  : # IP is valid, continue
 else
   # Exiting due to invalid IP address
   echo "Invalid IP address from $GET_IP_WEBSITE"
@@ -70,12 +71,13 @@ else
 fi
 
 # Get Gandi DNS IP address
-if valid_ip $(curl -s -H "Authorization: Apikey $API_KEY" -X GET https://api.gandi.net/v5/livedns/domains/$DOMAIN/records/$HOST/A | jq -r '.rrset_values[0]')
+IP_GANDI=$(curl -s -H "Authorization: Apikey $API_KEY" -X GET https://api.gandi.net/v5/livedns/domains/$DOMAIN/records/$HOST/A | jq -r '.rrset_values[0]')
+if valid_ip "$IP_GANDI"
 then
-  IP_GANDI=$(curl -s -H "Authorization: Apikey $API_KEY" -X GET https://api.gandi.net/v5/livedns/domains/$DOMAIN/records/$HOST/A | jq -r '.rrset_values[0]')
+  : # IP is valid, continue
 else
   # Exiting due to invalid IP address
-  echo "Invalid IP address from Gandi API"
+  echo "Invalid IP address ($IP_GANDI) from Gandi API for ${DOMAIN}/${HOST}/A"
   exit 1
 fi
 
@@ -86,12 +88,27 @@ then
   echo "No update required"
   exit 0
 else
-  curl -s -H "Authorization: Apikey $API_KEY" -H "Content-Type: application/json" -d '{"rrset_values": ["'${IP_NOW}'"], "rrset_ttl": 1800}' -X PUT https://api.gandi.net/v5/livedns/domains/"${DOMAIN}"/records/"${HOST}"/A > /dev/null
+  RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Apikey $API_KEY" -H "Content-Type: application/json" -d '{"rrset_values": ["'${IP_NOW}'"], "rrset_ttl": 1800}' -X PUT https://api.gandi.net/v5/livedns/domains/"${DOMAIN}"/records/"${HOST}"/A)
   if [ "$?" -ne 0 ]
   then
     echo "There was a problem running the LiveDNS update command"
     exit 1
-  else
-    echo "DNS record updated"
   fi
+
+  # curl exits 0 when it successfully receives an HTTP error such as 401 or
+  # 403, so the response code has to be checked separately or a rejected
+  # update looks identical to a successful one.
+  HTTP_CODE=$(echo "$RESPONSE" | tail -n 1)
+  BODY=$(echo "$RESPONSE" | sed '$d')
+  case "$HTTP_CODE" in
+    2[0-9][0-9])
+      : # Updated, continue
+      ;;
+    *)
+      echo "LiveDNS rejected the update (HTTP ${HTTP_CODE:-none}): $(echo "$BODY" | jq -r '.message // .cause // "no message"' 2>/dev/null || echo "no message")"
+      exit 1
+      ;;
+  esac
+
+  echo "DNS record updated"
 fi

--- a/porkbun-dynamic-dns.sh
+++ b/porkbun-dynamic-dns.sh
@@ -88,12 +88,21 @@ then
   # They are the same, exiting
   exit 0
 else
-  curl -s -X POST -H "Content-Type: application/json" -d '{"apikey": "'"${API_KEY}"'", "secretapikey": "'"${SECRET_KEY}"'", "content": "'"${IP_NOW}"'", "ttl": "1800"}' "https://api.porkbun.com/api/json/v3/dns/editByNameType/${DOMAIN}/A/${HOST}" > /dev/null
+  RESPONSE=$(curl -s -X POST -H "Content-Type: application/json" -d '{"apikey": "'"${API_KEY}"'", "secretapikey": "'"${SECRET_KEY}"'", "content": "'"${IP_NOW}"'", "ttl": "1800"}' "https://api.porkbun.com/api/json/v3/dns/editByNameType/${DOMAIN}/A/${HOST}")
   if [ "$?" -ne 0 ]
   then
     echo "There was a problem running the Porkbun DNS update command"
     exit 1
-  else
-    echo "DNS record updated"
   fi
+
+  # Porkbun answers HTTP 200 with {"status":"ERROR"} for application-level
+  # failures such as a bad key or a record that does not exist, so curl's exit
+  # status alone does not tell us the record was actually updated.
+  if [ "$(echo "$RESPONSE" | jq -r '.status')" != "SUCCESS" ]
+  then
+    echo "Porkbun rejected the update: $(echo "$RESPONSE" | jq -r '.message // "no message"')"
+    exit 1
+  fi
+
+  echo "DNS record updated"
 fi


### PR DESCRIPTION
Both scripts could report `DNS record updated` and exit 0 without having updated anything. They run from cron, so that failure stays invisible until someone tries to reach the host by name — which is exactly when you need the record to have been right.

Found while adapting `porkbun-dynamic-dns.sh` for a dual-WAN router, where a stale record silently disables VPN failover.

## Commits

Split by script, since they are the same symptom by two different mechanisms.

### `193e801` — Porkbun: detect API errors instead of trusting curl's exit status

Porkbun answers **HTTP 200 with `{"status":"ERROR"}`** for application-level failures — bad API key, API access not enabled for the domain, record does not exist. `curl` exits 0 for all of them, and the response was being discarded to `/dev/null`.

Now captures the body and requires `status == SUCCESS`, surfacing the API's own `message` when it is not.

### `211f15e` — Gandi: three fixes

1. **Dependency checks never ran.** `if [ ! command -v curl &> /dev/null ]` passes `!`, `command`, `-v`, `curl` to `[` as strings rather than running `command`. It never tested anything. Dropped the brackets to match the form `porkbun-dynamic-dns.sh` already uses.
2. **A rejected update looked like a successful one.** Same symptom as the Porkbun commit, different mechanism: Gandi returns proper 4xx codes, but `curl` exits 0 when it successfully *receives* a 401 or 403, and the response went to `/dev/null`. Now checks the response code and reports LiveDNS's message on refusal.
3. **Both addresses were fetched twice**, once to validate and once to keep — two round trips per run against both ifconfig.co and the Gandi API, with the value able to change in between. Assign first, then validate what was assigned.

## Reviewer notes

- **Success paths are structurally unchanged.** Every change either adds a rejection path or removes a duplicate request.
- **Not run against a live API.** Syntax checked, and the decision logic exercised against mock payloads: the Porkbun branch rejects `ERROR`, empty bodies and HTML error pages; the Gandi branch accepts 200/201 and rejects 4xx/5xx, empty, and non-numeric codes. `jq` was not available on the machine used, so the Porkbun check ran against a stub. Worth one manual run with real credentials before relying on it.
- Gandi's `PUT` returns **201** on success, so the check accepts any 2xx rather than testing for 200.
- Style deliberately follows each file's existing conventions rather than modernizing anything, to keep the diffs reviewable.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
